### PR TITLE
feat(tls): enable tls as secret, change ingress.tls to boolean

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .Values.ingress.tlsSecret }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -37,15 +37,12 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    {{- if .Values.ingress.host }}
+    - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
@@ -56,6 +53,5 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -42,12 +42,16 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: demo.openproject-dev.com
-      paths:
-        - path: /
-          pathType: Prefix
-  tls: []
+  host: openproject.local    
+  path: /
+  pathType: Prefix
+  tls: true
+  ## @param ingress.tlsSecret The tls configuration for hostnames to be covered with this ingress record.
+  ## tlsSecret:
+  ## - hosts:
+  ##     - openproject.local
+  ##   secretName: openproject-local-tls
+  tlsSecret: []
 
 resources: {}
 


### PR DESCRIPTION
Changes on `values.yml`:
* `ingress.tls` now is a boolean which activates the `tls` section on the `ingress`
* `ingress.tlsSecret` _not "conviced" about the var name_  this value is used to set the tls certs from a secret.
i. e:
```
tlsSecret:
- hosts:
  - openproject.local
  secretName: openproject-local-tls
```

The host configuration now is on the root of the value `ingress` because it's easier to change the `hostname`. Before these change to specify a different hostname, all the elements (basePath, pathType...) must be defined also. 

